### PR TITLE
v4.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vnc-rs"
-version = "0.3.4"
+version = "0.4.0"
 edition = "2021"
 authors  = ["Jovi Hsu <jv.hsu@outlook.com>"]
 license = "MIT OR Apache-2.0"
@@ -27,10 +27,16 @@ flate2 = "^1.0"
 tracing = { version = "^0.1", features = ["log"] }
 
 # async
+async_io_stream = "0.3"
+futures = "0.3.25"
+tokio-util = { version = "0.7.7", features = ["compat"] }
+tokio-stream = "0.1.12"
+
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 tokio = { version = "^1", features = ["full"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
+wasm-bindgen-futures = "0.4.33"
 tokio = { version = "^1", features = [
     "sync",
     "macros",

--- a/README.md
+++ b/README.md
@@ -74,21 +74,29 @@ async fn main() -> Result<()> {
         .try_start()
         .await?
         .finish()?;
-    let (vnc_event_sender, mut vnc_event_receiver) = tokio::sync::mpsc::channel(100);
-    let (x11_event_sender, x11_event_receiver) = tokio::sync::mpsc::channel(100);
-    tokio::spawn(async move { vnc.run(vnc_event_sender, x11_event_receiver).await.unwrap() });
 
     let mut canvas = CanvasUtils::new()?;
 
-    while let Some(event) = vnc_event_receiver.recv().await {
-        canvas.hande_vnc_event(event)?;
-        while let Ok(e) = vnc_event_receiver.try_recv() {
-            canvas.hande_vnc_event(e)?;
+    let mut now = std::time::Instant::now();
+    loop {
+        match vnc.poll_event().await {
+            Ok(Some(e)) => {
+                let _ = canvas.hande_vnc_event(e);
+            }
+            Ok(None) => (),
+            Err(e) => {
+                tracing::error!("{}", e.to_string());
+                break;
+            }
         }
-        canvas.flush()?;
-        let _ = x11_event_sender.send(X11Event::Refresh).await;
+        if now.elapsed().as_millis() > 16 {
+            let _ = canvas.flush();
+            let _ = vnc.input(X11Event::Refresh).await;
+            now = std::time::Instant::now();
+        }
     }
     canvas.close();
+    let _ = vnc.close().await;
     Ok(())
 }
 

--- a/src/client/connection.rs
+++ b/src/client/connection.rs
@@ -1,13 +1,29 @@
 use anyhow::{Ok, Result};
+use futures::TryStreamExt;
+use tokio_stream::wrappers::ReceiverStream;
 
-use std::vec;
+use std::{future::Future, sync::Arc, vec};
 use tokio::{
     io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt},
-    sync::mpsc::{Receiver, Sender},
+    sync::{
+        mpsc::{
+            channel,
+            error::{TryRecvError, TrySendError},
+            Receiver, Sender,
+        },
+        oneshot, Mutex,
+    },
 };
+use tokio_util::compat::*;
 use tracing::{info, trace};
 
-use crate::{codec, PixelFormat, Rect, VncEncoding, VncEvent, X11Event};
+use crate::{codec, PixelFormat, Rect, VncEncoding, VncError, VncEvent, X11Event};
+const CHANNEL_SIZE: usize = 4096;
+
+#[cfg(not(target_arch = "wasm32"))]
+use tokio::spawn;
+#[cfg(target_arch = "wasm32")]
+use wasm_bindgen_futures::spawn_local as spawn;
 
 use super::messages::{ClientMsg, ServerMsg};
 
@@ -45,228 +61,413 @@ impl ImageRect {
     }
 }
 
-/// The instance of a connected vnc client
-pub struct VncClient<S>
-where
-    S: AsyncRead + AsyncWrite + Unpin,
-{
-    stream: S,
-    shared: bool,
-    pixel_format: Option<PixelFormat>,
+struct VncInner {
     name: String,
-    encodings: Vec<VncEncoding>,
     screen: (u16, u16),
+    input_ch: Sender<ClientMsg>,
+    output_ch: Receiver<VncEvent>,
+    decoding_stop: Option<oneshot::Sender<()>>,
+    net_conn_stop: Option<oneshot::Sender<()>>,
+    closed: bool,
 }
 
-impl<S> VncClient<S>
-where
-    S: AsyncRead + AsyncWrite + Unpin,
-{
-    pub(super) fn new(
+/// The instance of a connected vnc client
+
+impl VncInner {
+    async fn new<S>(
+        mut stream: S,
+        shared: bool,
+        mut pixel_format: Option<PixelFormat>,
+        encodings: Vec<VncEncoding>,
+    ) -> Result<Self>
+    where
+        S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+    {
+        let (conn_ch_tx, conn_ch_rx) = channel(CHANNEL_SIZE);
+        let (input_ch_tx, input_ch_rx) = channel(CHANNEL_SIZE);
+        let (output_ch_tx, output_ch_rx) = channel(CHANNEL_SIZE);
+        let (decoding_stop_tx, decoding_stop_rx) = oneshot::channel();
+        let (net_conn_stop_tx, net_conn_stop_rx) = oneshot::channel();
+
+        trace!("client init msg");
+        send_client_init(&mut stream, shared).await?;
+
+        trace!("server init msg");
+        let (name, (width, height)) =
+            read_server_init(&mut stream, &mut pixel_format, &|e| async {
+                output_ch_tx.send(e).await?;
+                Ok(())
+            })
+            .await?;
+
+        trace!("client encodings: {:?}", encodings);
+        send_client_encoding(&mut stream, encodings).await?;
+
+        trace!("Require the first frame");
+        input_ch_tx
+            .send(ClientMsg::FramebufferUpdateRequest(
+                Rect {
+                    x: 0,
+                    y: 0,
+                    width,
+                    height,
+                },
+                0,
+            ))
+            .await?;
+
+        // start the decoding thread
+        spawn(async move {
+            let mut conn_ch_rx = {
+                let conn_ch_rx = ReceiverStream::new(conn_ch_rx).into_async_read();
+                FuturesAsyncReadCompatExt::compat(conn_ch_rx)
+            };
+
+            let output_func = |e| async {
+                output_ch_tx.send(e).await?;
+                Ok(())
+            };
+
+            let pf = pixel_format.as_ref().unwrap();
+            if let Err(e) =
+                asycn_vnc_read_loop(&mut conn_ch_rx, &pf, &output_func, decoding_stop_rx).await
+            {
+                let _ = output_func(VncEvent::Error(e.to_string())).await;
+            }
+        });
+
+        // start the traffic process loop
+        spawn(async move {
+            let _ =
+                async_connection_process_loop(stream, input_ch_rx, conn_ch_tx, net_conn_stop_rx)
+                    .await;
+        });
+
+        info!("VNC Client {name} starts");
+        Ok(Self {
+            name,
+            screen: (width, height),
+            input_ch: input_ch_tx,
+            output_ch: output_ch_rx,
+            decoding_stop: Some(decoding_stop_tx),
+            net_conn_stop: Some(net_conn_stop_tx),
+            closed: false,
+        })
+    }
+
+    async fn input(&mut self, event: X11Event) -> Result<()> {
+        if self.closed {
+            Err(VncError::ClientNotRunning.into())
+        } else {
+            let msg = match event {
+                X11Event::Refresh => ClientMsg::FramebufferUpdateRequest(
+                    Rect {
+                        x: 0,
+                        y: 0,
+                        width: self.screen.0,
+                        height: self.screen.1,
+                    },
+                    1,
+                ),
+                X11Event::KeyEvent(key) => ClientMsg::KeyEvent(key.keycode, key.down),
+                X11Event::PointerEvent(mouse) => {
+                    ClientMsg::PointerEvent(mouse.position_x, mouse.position_y, mouse.bottons)
+                }
+                X11Event::CopyText(text) => ClientMsg::ClientCutText(text),
+            };
+            self.input_ch.send(msg).await?;
+            Ok(())
+        }
+    }
+
+    async fn poll_event(&mut self) -> Result<Option<VncEvent>> {
+        use std::result::Result::Ok;
+
+        if self.closed {
+            Err(VncError::ClientNotRunning.into())
+        } else {
+            match self.output_ch.try_recv() {
+                Err(TryRecvError::Disconnected) => Err(VncError::ClientNotRunning.into()),
+                Err(TryRecvError::Empty) => Ok(None),
+                Ok(e) => Ok(Some(e)),
+            }
+            // Ok(self.output_ch.recv().await)
+        }
+    }
+
+    /// Stop the VNC engine and release resources
+    ///
+    async fn close(&mut self) -> Result<()> {
+        if self.closed {
+            Err(VncError::ClientNotRunning.into())
+        } else {
+            if self.net_conn_stop.is_some() {
+                let net_conn_stop = self.net_conn_stop.take().unwrap();
+                let _ = net_conn_stop.send(());
+            }
+            if self.decoding_stop.is_some() {
+                let decoding_stop = self.decoding_stop.take().unwrap();
+                let _ = decoding_stop.send(());
+            }
+            self.closed = true;
+            Ok(())
+        }
+    }
+}
+
+impl Drop for VncInner {
+    fn drop(&mut self) {
+        info!("VNC Client {} stops", self.name);
+    }
+}
+
+pub struct VncClient {
+    inner: Arc<Mutex<VncInner>>,
+}
+
+impl VncClient {
+    pub(super) async fn new<S>(
         stream: S,
         shared: bool,
         pixel_format: Option<PixelFormat>,
         encodings: Vec<VncEncoding>,
-    ) -> Self {
-        Self {
-            stream,
-            shared,
-            pixel_format,
-            name: String::new(),
-            encodings,
-            screen: (0, 0),
-        }
+    ) -> Result<Self>
+    where
+        S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+    {
+        Ok(Self {
+            inner: Arc::new(Mutex::new(
+                VncInner::new(stream, shared, pixel_format, encodings).await?,
+            )),
+        })
     }
 
+    /// Input a `X11Event` from the frontend
     ///
-    /// Run the vnc engine
-    ///
-    /// Which will poll the data from the server and send output via `sender`
-    ///
-    /// Also poll the user input from the `recv`
-    ///
-    pub async fn run(
-        mut self,
-        sender: Sender<VncEvent>,
-        mut recv: Receiver<X11Event>,
-    ) -> Result<()> {
-        trace!("client init msg");
-        self.send_client_init().await?;
-        trace!("server init msg");
-        self.read_server_init(&sender).await?;
-        trace!("client encodings: {:?}", self.encodings);
-        self.send_client_encoding().await?;
-        trace!("Require the first frame");
-        ClientMsg::FramebufferUpdateRequest(
-            Rect {
-                x: 0,
-                y: 0,
-                width: self.screen.0,
-                height: self.screen.1,
-            },
-            0,
-        )
-        .write(&mut self.stream)
-        .await?;
+    pub async fn input(&self, event: X11Event) -> Result<()> {
+        self.inner.lock().await.input(event).await
+    }
 
-        trace!("Start main loop");
-        let mut raw_decoder = codec::RawDecoder::new();
-        let mut zrle_decoder = codec::ZrleDecoder::new();
-        let mut tight_decoder = codec::TightDecoder::new();
-        let mut trle_decoder = codec::TrleDecoder::new();
-        let mut cursor = codec::CursorDecoder::new();
-        let pf = self.pixel_format.as_ref().unwrap();
-        loop {
-            tokio::select! {
-                server_msg = ServerMsg::read(&mut self.stream) => {
-                    let server_msg = server_msg?;
-                    trace!("Server message got: {:?}", server_msg);
-                    match server_msg {
-                        ServerMsg::FramebufferUpdate(rect_num) => {
-                            for _ in 0..rect_num {
-                                let rect = ImageRect::read(&mut self.stream).await?;
-                                trace!("Encoding: {:?}", rect.encoding);
+    /// polling `VncEvent` from the engine and give it to the client
+    ///
+    pub async fn poll_event(&self) -> Result<Option<VncEvent>> {
+        self.inner.lock().await.poll_event().await
+    }
 
-                                match rect.encoding {
-                                    VncEncoding::Raw => {
-                                        raw_decoder.decode(pf, &rect.rect, &mut self.stream, &sender).await?;
-                                    }
-                                    VncEncoding::CopyRect => {
-                                        let source_x = self.stream.read_u16().await?;
-                                        let source_y = self.stream.read_u16().await?;
-                                        let mut src_rect = rect.rect;
-                                        src_rect.x = source_x;
-                                        src_rect.y = source_y;
-                                        sender.send(VncEvent::Copy(rect.rect, src_rect)).await?;
-                                    }
-                                    VncEncoding::Tight => {
-                                        tight_decoder.decode(pf, &rect.rect, &mut self.stream, &sender).await?;
-                                    }
-                                    VncEncoding::Trle => {
-                                        trle_decoder.decode(pf, &rect.rect, &mut self.stream, &sender).await?;
-                                    }
-                                    VncEncoding::Zrle => {
-                                        zrle_decoder.decode(pf, &rect.rect, &mut self.stream, &sender).await?;
-                                    }
-                                    VncEncoding::CursorPseudo => {
-                                        cursor.decode(pf, &rect.rect, &mut self.stream, &sender).await?;
-                                    }
-                                    VncEncoding::DesktopSizePseudo => {
-                                        sender.send(VncEvent::SetResolution((rect.rect.width, rect.rect.height).into())).await?;
-                                    }
-                                    VncEncoding::LastRectPseudo => {
-                                        break;
-                                    }
-                                }
-                            }
-                        }
-                        // SetColorMapEntries,
-                        ServerMsg::Bell => {
-                            sender.send(VncEvent::Bell).await?;
-                        }
-                        ServerMsg::ServerCutText(text) => {
-                            sender.send(VncEvent::Text(text)).await?;
-                        }
-                    }
-                }
-                x11_event = recv.recv() => {
-                    if let Some(x11_event) = x11_event {
-                        match x11_event {
-                            X11Event::Refresh => {
-                                ClientMsg::FramebufferUpdateRequest(
-                                    Rect {
-                                        x: 0,
-                                        y: 0,
-                                        width: self.screen.0,
-                                        height: self.screen.1,
-                                    },
-                                    1,
-                                )
-                                .write(&mut self.stream)
+    /// Stop the VNC engine and release resources
+    ///
+    pub async fn close(&self) -> Result<()> {
+        self.inner.lock().await.close().await
+    }
+}
+
+impl Clone for VncClient {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+        }
+    }
+}
+
+async fn send_client_init<S>(stream: &mut S, shared: bool) -> Result<()>
+where
+    S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+{
+    trace!("Send shared flag: {}", shared);
+    stream.write_u8(shared as u8).await?;
+    Ok(())
+}
+
+async fn read_server_init<S, F, Fut>(
+    stream: &mut S,
+    pf: &mut Option<PixelFormat>,
+    output_func: &F,
+) -> Result<(String, (u16, u16))>
+where
+    S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+    F: Fn(VncEvent) -> Fut,
+    Fut: Future<Output = Result<()>>,
+{
+    // +--------------+--------------+------------------------------+
+    // | No. of bytes | Type [Value] | Description                  |
+    // +--------------+--------------+------------------------------+
+    // | 2            | U16          | framebuffer-width in pixels  |
+    // | 2            | U16          | framebuffer-height in pixels |
+    // | 16           | PIXEL_FORMAT | server-pixel-format          |
+    // | 4            | U32          | name-length                  |
+    // | name-length  | U8 array     | name-string                  |
+    // +--------------+--------------+------------------------------+
+
+    let screen_width = stream.read_u16().await?;
+    let screen_height = stream.read_u16().await?;
+    let mut send_our_pf = false;
+
+    output_func(VncEvent::SetResolution(
+        (screen_width, screen_height).into(),
+    ))
+    .await?;
+
+    let pixel_format = PixelFormat::read(stream).await?;
+    if pf.is_none() {
+        output_func(VncEvent::SetPixelFormat(pixel_format)).await?;
+        let _ = pf.insert(pixel_format);
+    } else {
+        send_our_pf = true;
+    }
+
+    let name_len = stream.read_u32().await?;
+    let mut name_buf = vec![0_u8; name_len as usize];
+    stream.read_exact(&mut name_buf).await?;
+    let name = String::from_utf8(name_buf)?;
+
+    if send_our_pf {
+        trace!("Send customized pixel format {:#?}", pf);
+        ClientMsg::SetPixelFormat(*pf.as_ref().unwrap())
+            .write(stream)
+            .await?;
+    }
+    Ok((name, (screen_width, screen_height)))
+}
+
+async fn send_client_encoding<S>(stream: &mut S, encodings: Vec<VncEncoding>) -> Result<()>
+where
+    S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+{
+    ClientMsg::SetEncodings(encodings).write(stream).await?;
+    Ok(())
+}
+
+async fn asycn_vnc_read_loop<S, F, Fut>(
+    stream: &mut S,
+    pf: &PixelFormat,
+    output_func: &F,
+    mut stop_ch: oneshot::Receiver<()>,
+) -> Result<()>
+where
+    S: AsyncRead + Unpin,
+    F: Fn(VncEvent) -> Fut,
+    Fut: Future<Output = Result<()>>,
+{
+    trace!("Decoding thread starts");
+    let mut raw_decoder = codec::RawDecoder::new();
+    let mut zrle_decoder = codec::ZrleDecoder::new();
+    let mut tight_decoder = codec::TightDecoder::new();
+    let mut trle_decoder = codec::TrleDecoder::new();
+    let mut cursor = codec::CursorDecoder::new();
+    loop {
+        let server_msg = ServerMsg::read(stream).await?;
+        trace!("Server message got: {:?}", server_msg);
+        match server_msg {
+            ServerMsg::FramebufferUpdate(rect_num) => {
+                for _ in 0..rect_num {
+                    let rect = ImageRect::read(stream).await?;
+                    // trace!("Encoding: {:?}", rect.encoding);
+
+                    match rect.encoding {
+                        VncEncoding::Raw => {
+                            raw_decoder
+                                .decode(pf, &rect.rect, stream, output_func)
                                 .await?;
-                            },
-                            X11Event::KeyEvent(key) => {
-                                ClientMsg::KeyEvent(key.keycode, key.down).write(&mut self.stream).await?;
-                            },
-                            X11Event::PointerEvent(mouse) => {
-                                ClientMsg::PointerEvent(mouse.position_x, mouse.position_y, mouse.bottons).write(&mut self.stream).await?;
-                            },
-                            X11Event::CopyText(text) => {
-                                ClientMsg::ClientCutText(text).write(&mut self.stream).await?;
-                            },
+                        }
+                        VncEncoding::CopyRect => {
+                            let source_x = stream.read_u16().await?;
+                            let source_y = stream.read_u16().await?;
+                            let mut src_rect = rect.rect;
+                            src_rect.x = source_x;
+                            src_rect.y = source_y;
+                            output_func(VncEvent::Copy(rect.rect, src_rect)).await?;
+                        }
+                        VncEncoding::Tight => {
+                            tight_decoder
+                                .decode(pf, &rect.rect, stream, output_func)
+                                .await?;
+                        }
+                        VncEncoding::Trle => {
+                            trle_decoder
+                                .decode(pf, &rect.rect, stream, output_func)
+                                .await?;
+                        }
+                        VncEncoding::Zrle => {
+                            zrle_decoder
+                                .decode(pf, &rect.rect, stream, output_func)
+                                .await?;
+                        }
+                        VncEncoding::CursorPseudo => {
+                            cursor.decode(pf, &rect.rect, stream, output_func).await?;
+                        }
+                        VncEncoding::DesktopSizePseudo => {
+                            output_func(VncEvent::SetResolution(
+                                (rect.rect.width, rect.rect.height).into(),
+                            ))
+                            .await?;
+                        }
+                        VncEncoding::LastRectPseudo => {
+                            break;
                         }
                     }
                 }
             }
+            // SetColorMapEntries,
+            ServerMsg::Bell => {
+                output_func(VncEvent::Bell).await?;
+            }
+            ServerMsg::ServerCutText(text) => {
+                output_func(VncEvent::Text(text)).await?;
+            }
+        }
+        match stop_ch.try_recv() {
+            Err(oneshot::error::TryRecvError::Empty) => continue,
+            _ => break,
         }
     }
-
-    async fn send_client_init(&mut self) -> Result<()> {
-        info!("Send shared flag: {}", self.shared);
-        self.stream.write_u8(self.shared as u8).await?;
-        Ok(())
-    }
-
-    async fn read_server_init(&mut self, sender: &Sender<VncEvent>) -> Result<()> {
-        // +--------------+--------------+------------------------------+
-        // | No. of bytes | Type [Value] | Description                  |
-        // +--------------+--------------+------------------------------+
-        // | 2            | U16          | framebuffer-width in pixels  |
-        // | 2            | U16          | framebuffer-height in pixels |
-        // | 16           | PIXEL_FORMAT | server-pixel-format          |
-        // | 4            | U32          | name-length                  |
-        // | name-length  | U8 array     | name-string                  |
-        // +--------------+--------------+------------------------------+
-
-        let screen_width = self.stream.read_u16().await?;
-        let screen_height = self.stream.read_u16().await?;
-        let mut send_our_pf = false;
-
-        sender
-            .send(VncEvent::SetResolution(
-                (screen_width, screen_height).into(),
-            ))
-            .await?;
-        self.screen = (screen_width, screen_height);
-
-        let pixel_format = PixelFormat::read(&mut self.stream).await?;
-        if self.pixel_format.is_none() {
-            sender.send(VncEvent::SetPixelFormat(pixel_format)).await?;
-            self.pixel_format = Some(pixel_format);
-        } else {
-            send_our_pf = true;
-        }
-
-        let name_len = self.stream.read_u32().await?;
-        let mut name_buf = vec![0_u8; name_len as usize];
-        self.stream.read_exact(&mut name_buf).await?;
-        self.name = String::from_utf8(name_buf)?;
-
-        if send_our_pf {
-            info!(
-                "Send customized pixel format {:#?}",
-                self.pixel_format.as_ref().unwrap()
-            );
-            ClientMsg::SetPixelFormat(*self.pixel_format.as_ref().unwrap())
-                .write(&mut self.stream)
-                .await?;
-        }
-        Ok(())
-    }
-
-    async fn send_client_encoding(&mut self) -> Result<()> {
-        ClientMsg::SetEncodings(self.encodings.clone())
-            .write(&mut self.stream)
-            .await?;
-        Ok(())
-    }
+    trace!("Decoding thread stops");
+    Ok(())
 }
 
-impl<S> Drop for VncClient<S>
+async fn async_connection_process_loop<S>(
+    mut stream: S,
+    mut input_ch: Receiver<ClientMsg>,
+    conn_ch: Sender<std::io::Result<Vec<u8>>>,
+    mut stop_ch: oneshot::Receiver<()>,
+) -> Result<()>
 where
-    S: AsyncRead + AsyncWrite + Unpin,
+    S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
 {
-    fn drop(&mut self) {
-        trace!("Client closed");
+    trace!("Net Connection thread starts");
+    let mut buffer = [0; 65535];
+    // let mut nread = 0;
+    let mut pending = 0;
+    loop {
+        use std::result::Result::Ok;
+
+        match stop_ch.try_recv() {
+            Err(oneshot::error::TryRecvError::Empty) => (),
+            _ => break,
+        }
+
+        if pending > 0 {
+            match conn_ch.try_send(Ok(buffer[0..pending].to_owned())) {
+                Err(TrySendError::Full(_message)) => (),
+                Err(TrySendError::Closed(_message)) => break,
+                Ok(()) => pending = 0,
+            }
+        }
+
+        tokio::select! {
+            Ok(nread) = stream.read(&mut buffer), if pending == 0 => {
+                if nread > 0 {
+                    match conn_ch.try_send(Ok(buffer[0..nread].to_owned())) {
+                        Err(TrySendError::Full(_message)) => pending = nread,
+                        Err(TrySendError::Closed(_message)) => break,
+                        Ok(()) => ()
+                    }
+                }
+            }
+            Some(msg) = input_ch.recv() => {
+                msg.write(&mut stream).await?;
+            }
+        }
     }
+    trace!("Net Connection thread stops");
+    Ok(())
 }

--- a/src/client/connection.rs
+++ b/src/client/connection.rs
@@ -130,7 +130,7 @@ impl VncInner {
 
             let pf = pixel_format.as_ref().unwrap();
             if let Err(e) =
-                asycn_vnc_read_loop(&mut conn_ch_rx, &pf, &output_func, decoding_stop_rx).await
+                asycn_vnc_read_loop(&mut conn_ch_rx, pf, &output_func, decoding_stop_rx).await
             {
                 let _ = output_func(VncEvent::Error(e.to_string())).await;
             }

--- a/src/client/messages.rs
+++ b/src/client/messages.rs
@@ -2,6 +2,7 @@ use crate::{PixelFormat, Rect, VncEncoding, VncError};
 use anyhow::Result;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
+#[derive(Debug)]
 pub(super) enum ClientMsg {
     SetPixelFormat(PixelFormat),
     SetEncodings(Vec<VncEncoding>),

--- a/src/codec/trle.rs
+++ b/src/codec/trle.rs
@@ -1,9 +1,7 @@
 use crate::{PixelFormat, Rect, VncError, VncEvent};
 use anyhow::Result;
-use tokio::{
-    io::{AsyncRead, AsyncReadExt},
-    sync::mpsc::Sender,
-};
+use std::future::Future;
+use tokio::io::{AsyncRead, AsyncReadExt};
 use tracing::error;
 
 use super::uninit_vec;
@@ -54,15 +52,17 @@ impl Decoder {
         Self {}
     }
 
-    pub async fn decode<S>(
+    pub async fn decode<S, F, Fut>(
         &mut self,
         format: &PixelFormat,
         rect: &Rect,
         input: &mut S,
-        output: &Sender<VncEvent>,
+        output_func: &F,
     ) -> Result<()>
     where
         S: AsyncRead + Unpin,
+        F: Fn(VncEvent) -> Fut,
+        Fut: Future<Output = Result<()>>,
     {
         let data_len = input.read_u32().await? as usize;
         let mut zlib_data = uninit_vec(data_len);
@@ -202,17 +202,16 @@ impl Decoder {
                         return Err(VncError::InvalidImageData.into());
                     }
                 }
-                output
-                    .send(VncEvent::RawImage(
-                        Rect {
-                            x: rect.x + x,
-                            y: rect.y + y,
-                            width,
-                            height,
-                        },
-                        pixels,
-                    ))
-                    .await?;
+                output_func(VncEvent::RawImage(
+                    Rect {
+                        x: rect.x + x,
+                        y: rect.y + y,
+                        width,
+                        height,
+                    },
+                    pixels,
+                ))
+                .await?;
                 x += width;
             }
             y += height;

--- a/src/error.rs
+++ b/src/error.rs
@@ -19,6 +19,8 @@ pub enum VncError {
     WrongServerMessage,
     #[error("Image data cannot be decoded correctly")]
     InvalidImageData,
+    #[error("The vnc client hasn't been started")]
+    ClientNotRunning,
     #[error("Vnc Error with message: {0}")]
     Custom(String),
 }

--- a/src/event.rs
+++ b/src/event.rs
@@ -81,6 +81,9 @@ pub enum VncEvent {
     /// According to [RFC6143](https://www.rfc-editor.org/rfc/rfc6143.html#section-7.6.4)
     ///
     Text(String),
+    /// If any unexpected error happens in the async process routines
+    /// This event will propagate the error to the current context
+    Error(String),
 }
 
 /// X11 keyboard event to notify the server

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,24 +39,31 @@
 //!         .try_start()
 //!         .await?
 //!         .finish()?;
-//!     let (vnc_event_sender, mut vnc_event_receiver) = tokio::sync::mpsc::channel(100);
-//!     let (x11_event_sender, x11_event_receiver) = tokio::sync::mpsc::channel(100);
-//!     tokio::spawn(async move { vnc.run(vnc_event_sender, x11_event_receiver).await.unwrap() });
 //!
 //!     let mut canvas = CanvasUtils::new()?;
 //!
-//!     while let Some(event) = vnc_event_receiver.recv().await {
-//!         canvas.hande_vnc_event(event)?;
-//!         while let Ok(e) = vnc_event_receiver.try_recv() {
-//!             canvas.hande_vnc_event(e)?;
+//!     let mut now = std::time::Instant::now();
+//!     loop {
+//!         match vnc.poll_event().await {
+//!             Ok(Some(e)) => {
+//!                 let _ = canvas.hande_vnc_event(e);
+//!             }
+//!             Ok(None) => (),
+//!             Err(e) => {
+//!                 tracing::error!("{}", e.to_string());
+//!                 break;
+//!             }
 //!         }
-//!         canvas.flush()?;
-//!         let _ = x11_event_sender.send(X11Event::Refresh).await;
+//!         if now.elapsed().as_millis() > 16 {
+//!             let _ = canvas.flush();
+//!             let _ = vnc.input(X11Event::Refresh).await;
+//!             now = std::time::Instant::now();
+//!         }
 //!     }
 //!     canvas.close();
+//!     let _ = vnc.close().await;
 //!     Ok(())
 //! }
-//!
 //!
 //! struct CanvasUtils {
 //!     window: Window,
@@ -180,6 +187,7 @@
 //!         Ok(())
 //!     }
 //! }
+//!
 //! ```
 //!
 //! ## License


### PR DESCRIPTION
Main changes:
1. Remove the `run` API from `VncClient`
2. Use `poll_event` and `input` to put choice back in the hands of the users
3. The user can now hold multiple copies of one VNC instance
4. The user can now have multiple instances of VNC clients