### PR TITLE
Improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,6 @@ path = "src/lib.rs"
 [dependencies]
 #error
 thiserror = "^1"
-anyhow = "^1"
 flate2 = "^1"
 
 #log

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -45,8 +45,9 @@ tokio = { version = "^1", features = [
     ]}
 
 [dev-dependencies]
+anyhow = "^1"
 tracing-subscriber = { version = "^0.3" }
-minifb = "0.23.0"
+minifb = "0.25.0"
 
 
 [profile.release]

--- a/src/client/connector.rs
+++ b/src/client/connector.rs
@@ -24,7 +24,9 @@ where
     S: AsyncRead + AsyncWrite + Unpin + Send + Sync + 'static,
     F: Future<Output = Result<String, VncError>> + Send + Sync + 'static,
 {
-    pub fn try_start(self) -> Pin<Box<dyn Future<Output = Result<Self, VncError>> + Send + Sync + 'static>> {
+    pub fn try_start(
+        self,
+    ) -> Pin<Box<dyn Future<Output = Result<Self, VncError>> + Send + Sync + 'static>> {
         Box::pin(async move {
             match self {
                 VncState::Handshake(mut connector) => {
@@ -148,7 +150,7 @@ where
         if let VncState::Connected(client) = self {
             Ok(client)
         } else {
-            Err(VncError::ConnectError.into())
+            Err(VncError::ConnectError)
         }
     }
 }
@@ -177,12 +179,11 @@ where
     /// `S` should implement async I/O methods
     ///
     /// ```no_run
-    /// use vnc::{PixelFormat, VncConnector};
+    /// use vnc::{PixelFormat, VncConnector, VncError};
     /// use tokio::{self, net::TcpStream};
-    /// use anyhow::Result;
     ///
     /// #[tokio::main]
-    /// async fn main() -> Result<()> {
+    /// async fn main() -> Result<(), VncError> {
     ///     let tcp = TcpStream::connect("127.0.0.1:5900").await?;
     ///     let vnc = VncConnector::new(tcp)
     ///         .set_auth_method(async move { Ok("password".to_string()) })
@@ -311,7 +312,7 @@ where
     ///
     pub fn build(self) -> Result<VncState<S, F>, VncError> {
         if self.encodings.is_empty() {
-            return Err(VncError::NoEncoding.into());
+            return Err(VncError::NoEncoding);
         }
         Ok(VncState::Handshake(self))
     }

--- a/src/client/connector.rs
+++ b/src/client/connector.rs
@@ -171,7 +171,7 @@ where
 impl<S, F> VncConnector<S, F>
 where
     S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
-    F: Future<Output = Result<String>>,
+    F: Future<Output = Result<String>> + Send + Sync + 'static,
 {
     /// To new a vnc client configuration with stream `S`
     ///

--- a/src/client/connector.rs
+++ b/src/client/connector.rs
@@ -12,8 +12,8 @@ use crate::{PixelFormat, VncEncoding, VncError, VncVersion};
 
 pub enum VncState<S, F>
 where
-    S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
-    F: Future<Output = Result<String>>,
+    S: AsyncRead + AsyncWrite + Unpin + Send + Sync + 'static,
+    F: Future<Output = Result<String>> + Send + Sync + 'static,
 {
     Handshake(VncConnector<S, F>),
     Authenticate(VncConnector<S, F>),
@@ -22,10 +22,10 @@ where
 
 impl<S, F> VncState<S, F>
 where
-    S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
-    F: Future<Output = Result<String>> + 'static,
+    S: AsyncRead + AsyncWrite + Unpin + Send + Sync + 'static,
+    F: Future<Output = Result<String>> + Send + Sync + 'static,
 {
-    pub fn try_start(self) -> Pin<Box<dyn Future<Output = Result<Self>>>> {
+    pub fn try_start(self) -> Pin<Box<dyn Future<Output = Result<Self>> + Send + Sync + 'static>> {
         Box::pin(async move {
             match self {
                 VncState::Handshake(mut connector) => {
@@ -158,7 +158,7 @@ where
 pub struct VncConnector<S, F>
 where
     S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
-    F: Future<Output = Result<String>>,
+    F: Future<Output = Result<String>> + Send + Sync + 'static,
 {
     stream: S,
     auth_methond: Option<F>,
@@ -170,7 +170,7 @@ where
 
 impl<S, F> VncConnector<S, F>
 where
-    S: AsyncRead + AsyncWrite + Unpin + Send + 'static,
+    S: AsyncRead + AsyncWrite + Unpin + Send + Sync + 'static,
     F: Future<Output = Result<String>> + Send + Sync + 'static,
 {
     /// To new a vnc client configuration with stream `S`

--- a/src/client/messages.rs
+++ b/src/client/messages.rs
@@ -1,5 +1,4 @@
 use crate::{PixelFormat, Rect, VncEncoding, VncError};
-use anyhow::Result;
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
 #[derive(Debug)]
@@ -13,7 +12,7 @@ pub(super) enum ClientMsg {
 }
 
 impl ClientMsg {
-    pub(super) async fn write<S>(self, writer: &mut S) -> Result<()>
+    pub(super) async fn write<S>(self, writer: &mut S) -> Result<(), VncError>
     where
         S: AsyncWrite + Unpin,
     {
@@ -130,7 +129,7 @@ pub(super) enum ServerMsg {
 }
 
 impl ServerMsg {
-    pub(super) async fn read<S>(reader: &mut S) -> Result<Self>
+    pub(super) async fn read<S>(reader: &mut S) -> Result<Self, VncError>
     where
         S: AsyncRead + Unpin,
     {

--- a/src/client/messages.rs
+++ b/src/client/messages.rs
@@ -189,7 +189,7 @@ impl ServerMsg {
                     String::from_utf8_lossy(&buffer_str).to_string(),
                 ))
             }
-            _ => Err(VncError::WrongServerMessage.into()),
+            _ => Err(VncError::WrongServerMessage),
         }
     }
 }

--- a/src/codec/cursor.rs
+++ b/src/codec/cursor.rs
@@ -1,5 +1,4 @@
-use crate::{PixelFormat, Rect, VncEvent};
-use anyhow::Result;
+use crate::{PixelFormat, Rect, VncError, VncEvent};
 use std::future::Future;
 use tokio::io::{AsyncRead, AsyncReadExt};
 
@@ -18,11 +17,11 @@ impl Decoder {
         rect: &Rect,
         input: &mut S,
         output_func: &F,
-    ) -> Result<()>
+    ) -> Result<(), VncError>
     where
         S: AsyncRead + Unpin,
         F: Fn(VncEvent) -> Fut,
-        Fut: Future<Output = Result<()>>,
+        Fut: Future<Output = Result<(), VncError>>,
     {
         let _hotx = rect.x;
         let _hoty = rect.y;

--- a/src/codec/mod.rs
+++ b/src/codec/mod.rs
@@ -10,7 +10,7 @@ pub(crate) use tight::Decoder as TightDecoder;
 pub(crate) use trle::Decoder as TrleDecoder;
 pub(crate) use zrle::Decoder as ZrleDecoder;
 
-pub(self) fn uninit_vec(len: usize) -> Vec<u8> {
+fn uninit_vec(len: usize) -> Vec<u8> {
     let mut v = Vec::with_capacity(len);
     #[allow(clippy::uninit_vec)]
     unsafe {

--- a/src/codec/raw.rs
+++ b/src/codec/raw.rs
@@ -1,5 +1,4 @@
-use crate::{PixelFormat, Rect, VncEvent};
-use anyhow::Result;
+use crate::{PixelFormat, Rect, VncError, VncEvent};
 use std::future::Future;
 use tokio::io::{AsyncRead, AsyncReadExt};
 
@@ -18,11 +17,11 @@ impl Decoder {
         rect: &Rect,
         input: &mut S,
         output_func: &F,
-    ) -> Result<()>
+    ) -> Result<(), VncError>
     where
         S: AsyncRead + Unpin,
         F: Fn(VncEvent) -> Fut,
-        Fut: Future<Output = Result<()>>,
+        Fut: Future<Output = Result<(), VncError>>,
     {
         // +----------------------------+--------------+-------------+
         // | No. of bytes               | Type [Value] | Description |

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,13 +1,13 @@
 use thiserror::Error;
 
 #[non_exhaustive]
-#[derive(Debug, Error, Clone)]
+#[derive(Debug, Error)]
 pub enum VncError {
     #[error("Auth is required but no password provided")]
     NoPassword,
-    #[error("No vnc encoding selected")]
+    #[error("No VNC encoding selected")]
     NoEncoding,
-    #[error("Unknow vnc security type: {0}")]
+    #[error("Unknow VNC security type: {0}")]
     InvalidSecurityTyep(u8),
     #[error("Wrong password")]
     WrongPassword,
@@ -19,8 +19,16 @@ pub enum VncError {
     WrongServerMessage,
     #[error("Image data cannot be decoded correctly")]
     InvalidImageData,
-    #[error("The vnc client hasn't been started")]
+    #[error("The VNC client hasn't been started")]
     ClientNotRunning,
-    #[error("Vnc Error with message: {0}")]
+    #[error("I/O error: {0}")]
+    IoError(#[from] std::io::Error),
+    #[error("VNC Error with message: {0}")]
     General(String),
+}
+
+impl<T> From<tokio::sync::mpsc::error::SendError<T>> for VncError {
+    fn from(_value: tokio::sync::mpsc::error::SendError<T>) -> Self {
+        VncError::General("Channel closed".to_string())
+    }
 }


### PR DESCRIPTION
Hi there!
I've stumbled upon your nifty library and it's been real help.

However, I found that I had to do few changes for my use-case.
I feel those changes are general enough that they can be useful for everyone.

- [make auth_method Send + Sync + 'static](https://github.com/HsuJv/vnc-rs/commit/e95e0bccf88fa3311ff7ec49d5d7a84c1094de7a) & [make VncConnector & VncState Send/Sync friendly](https://github.com/HsuJv/vnc-rs/commit/727185e43dedae03411e2518a089863701eb1238): this is a main change and a **must** if you'd like to build VncClient e.g. from within tokio::spawn(), which requires Futures to be Send + 'static
- [get rid of anyhow crate](https://github.com/HsuJv/vnc-rs/commit/1e288f78f9ec835594ed5f0f178729e0f48e2623): anyhow isn't really supposed to be used in libraries - it makes capturing library-specific errors quite hard, so the code has been adjusted to return VncError
- [implement recv_event() method](https://github.com/HsuJv/vnc-rs/commit/616078901b5a30eedcac21a7663a134c47d7eef4): polling is cool, but I think recv-like method is more async-idiomatic :)