### PR TITLE
Close VNC connection on drop

### DIFF
--- a/src/client/connection.rs
+++ b/src/client/connection.rs
@@ -226,6 +226,7 @@ impl VncInner {
 impl Drop for VncInner {
     fn drop(&mut self) {
         info!("VNC Client {} stops", self.name);
+        let _ = self.close();
     }
 }
 


### PR DESCRIPTION
Hi!

If the VNC server closes the connection (e.g. VM or physical machine gets shut down), and the user doesn't call VncClient::close() manually, the async_connection_process_loop() get stuck in an infinite loop - because stop_ch is never triggered.

I would argue that it shouldn't be a user's responsibility to call a close() call - in similar vein that it's not a user's responsibility to call close on File or TcpStream.

This PR adds call to the VncInner::close() on Drop of VncInner to prevent a leak of a task that uses 100% of the CPU core.