### PR TITLE
fix: replace unsafe transmute with safe match and add FullRefresh support

### DIFF
--- a/src/client/connection.rs
+++ b/src/client/connection.rs
@@ -184,6 +184,15 @@ impl VncInner {
                     },
                     1,
                 ),
+                X11Event::FullRefresh => ClientMsg::FramebufferUpdateRequest(
+                    Rect {
+                        x: 0,
+                        y: 0,
+                        width: self.screen.0,
+                        height: self.screen.1,
+                    },
+                    0, // non-incremental: server sends entire framebuffer
+                ),
                 X11Event::KeyEvent(key) => ClientMsg::KeyEvent(key.keycode, key.down),
                 X11Event::PointerEvent(mouse) => {
                     ClientMsg::PointerEvent(mouse.position_x, mouse.position_y, mouse.bottons)

--- a/src/config.rs
+++ b/src/config.rs
@@ -20,7 +20,20 @@ pub enum VncEncoding {
 
 impl From<u32> for VncEncoding {
     fn from(num: u32) -> Self {
-        unsafe { std::mem::transmute(num) }
+        // Safe match instead of transmute — unknown encoding IDs fall back to Raw
+        // instead of causing UB (the original transmute is unsound for any value
+        // not matching a valid discriminant).
+        match num as i32 {
+            0 => VncEncoding::Raw,
+            1 => VncEncoding::CopyRect,
+            7 => VncEncoding::Tight,
+            15 => VncEncoding::Trle,
+            16 => VncEncoding::Zrle,
+            -239 => VncEncoding::CursorPseudo,
+            -223 => VncEncoding::DesktopSizePseudo,
+            -224 => VncEncoding::LastRectPseudo,
+            _ => VncEncoding::Raw,
+        }
     }
 }
 

--- a/src/event.rs
+++ b/src/event.rs
@@ -131,9 +131,13 @@ impl From<(u16, u16, u8)> for ClientMouseEvent {
 #[non_exhaustive]
 #[derive(Debug, Clone)]
 pub enum X11Event {
-    /// Require a frame update
+    /// Require an incremental frame update
     ///
     Refresh,
+    /// Require a full (non-incremental) frame update.
+    /// Forces the server to send the entire framebuffer, useful after
+    /// CursorPseudo is negotiated to clear cursor ghosts from the framebuffer.
+    FullRefresh,
     /// Key down/up
     ///
     KeyEvent(ClientKeyEvent),


### PR DESCRIPTION
fix: replace unsafe transmute with safe match and add FullRefresh support 
Replace `unsafe { std::mem::transmute(num) }` in `VncEncoding::from(u32)` with a safe `match` expression. The transmute causes undefined behavior when the server sends any encoding ID not matching a valid discriminant, which is common in practice and makes CursorPseudo unusable.

Add `X11Event::FullRefresh` variant that sends a non-incremental FramebufferUpdateRequest (incremental=0). This is needed after CursorPseudo is negotiated to clear thecursor ghost baked into the initial framebuffer before the server switched to out-of-band cursor delivery