### PR TITLE
extended desktop size

### DIFF
--- a/src/client/connection.rs
+++ b/src/client/connection.rs
@@ -204,12 +204,26 @@ impl VncInner {
         }
     }
 
+    /// Track server-driven state carried in events as they are handed to the
+    /// consumer. Keeping `screen` current matters: every
+    /// FramebufferUpdateRequest is built from it, and after a desktop grows a
+    /// stale (smaller) request rect would make the server permanently withhold
+    /// updates for the area outside it.
+    fn observe_event(&mut self, event: &VncEvent) {
+        if let VncEvent::SetResolution(screen) = event {
+            self.screen = (screen.width, screen.height);
+        }
+    }
+
     async fn recv_event(&mut self) -> Result<VncEvent, VncError> {
         if self.closed {
             Err(VncError::ClientNotRunning)
         } else {
             match self.output_ch.recv().await {
-                Some(e) => Ok(e),
+                Some(e) => {
+                    self.observe_event(&e);
+                    Ok(e)
+                }
                 None => {
                     self.closed = true;
                     Err(VncError::ClientNotRunning)
@@ -228,7 +242,10 @@ impl VncInner {
                     Err(VncError::ClientNotRunning)
                 }
                 Err(TryRecvError::Empty) => Ok(None),
-                Ok(e) => Ok(Some(e)),
+                Ok(e) => {
+                    self.observe_event(&e);
+                    Ok(Some(e))
+                }
             }
             // Ok(self.output_ch.recv().await)
         }

--- a/src/client/connection.rs
+++ b/src/client/connection.rs
@@ -16,7 +16,7 @@ use tokio::{
 use tokio_util::compat::*;
 use tracing::*;
 
-use crate::{codec, PixelFormat, Rect, VncEncoding, VncError, VncEvent, X11Event};
+use crate::{codec, PixelFormat, Rect, ScreenLayout, VncEncoding, VncError, VncEvent, X11Event};
 const CHANNEL_SIZE: usize = 4096;
 
 #[cfg(not(target_arch = "wasm32"))]
@@ -63,6 +63,9 @@ impl ImageRect {
 struct VncInner {
     name: String,
     screen: (u16, u16),
+    /// Last screen layout announced by the server via ExtendedDesktopSize.
+    /// Echoed back (with the new size) in SetDesktopSize requests.
+    screen_layout: Vec<ScreenLayout>,
     input_ch: Sender<ClientMsg>,
     output_ch: Receiver<VncEvent>,
     decoding_stop: Option<oneshot::Sender<()>>,
@@ -162,12 +165,40 @@ impl VncInner {
         Ok(Self {
             name,
             screen: (width, height),
+            screen_layout: Vec::new(),
             input_ch: input_ch_tx,
             output_ch: output_ch_rx,
             decoding_stop: Some(decoding_stop_tx),
             net_conn_stop: Some(net_conn_stop_tx),
             closed: false,
         })
+    }
+
+    /// Track server-driven state carried in events as they are handed to the
+    /// consumer. Keeping `screen` current matters: every
+    /// FramebufferUpdateRequest is built from it, and after a desktop grows a
+    /// stale (smaller) request rect would make the server permanently withhold
+    /// updates for the area outside it.
+    fn observe_event(&mut self, event: &VncEvent) {
+        match event {
+            VncEvent::SetResolution(screen) => {
+                self.screen = (screen.width, screen.height);
+            }
+            VncEvent::ExtendedDesktopSize {
+                screen,
+                reason,
+                status,
+                layout,
+            } => {
+                // status is only meaningful for reason 1 (our own request);
+                // a failed request leaves the desktop unchanged.
+                if !(*reason == 1 && *status != 0) {
+                    self.screen = (screen.width, screen.height);
+                    self.screen_layout = layout.clone();
+                }
+            }
+            _ => {}
+        }
     }
 
     async fn input(&mut self, event: X11Event) -> Result<(), VncError> {
@@ -198,20 +229,33 @@ impl VncInner {
                     ClientMsg::PointerEvent(mouse.position_x, mouse.position_y, mouse.bottons)
                 }
                 X11Event::CopyText(text) => ClientMsg::ClientCutText(text),
+                X11Event::SetDesktopSize(width, height) => {
+                    // Echo the server-announced layout with the primary screen
+                    // resized to the requested dimensions (multi-monitor
+                    // layouts are collapsed to a single screen). Servers
+                    // reject layouts whose screens don't tile the new size.
+                    let mut screens = self.screen_layout.clone();
+                    screens.truncate(1);
+                    if screens.is_empty() {
+                        screens.push(ScreenLayout {
+                            id: 0,
+                            x: 0,
+                            y: 0,
+                            width,
+                            height,
+                            flags: 0,
+                        });
+                    } else if let Some(s) = screens.first_mut() {
+                        s.x = 0;
+                        s.y = 0;
+                        s.width = width;
+                        s.height = height;
+                    }
+                    ClientMsg::SetDesktopSize(width, height, screens)
+                }
             };
             self.input_ch.send(msg).await?;
             Ok(())
-        }
-    }
-
-    /// Track server-driven state carried in events as they are handed to the
-    /// consumer. Keeping `screen` current matters: every
-    /// FramebufferUpdateRequest is built from it, and after a desktop grows a
-    /// stale (smaller) request rect would make the server permanently withhold
-    /// updates for the area outside it.
-    fn observe_event(&mut self, event: &VncEvent) {
-        if let VncEvent::SetResolution(screen) = event {
-            self.screen = (screen.width, screen.height);
         }
     }
 
@@ -463,6 +507,37 @@ where
                             output_func(VncEvent::SetResolution(
                                 (rect.rect.width, rect.rect.height).into(),
                             ))
+                            .await?;
+                        }
+                        VncEncoding::ExtendedDesktopSizePseudo => {
+                            // x = reason, y = status, width/height = new size.
+                            // Payload:
+                            // +--------------+--------------+-------------------+
+                            // | 1            | U8           | number-of-screens |
+                            // | 3            |              | padding           |
+                            // +--------------+--------------+-------------------+
+                            // then number-of-screens SCREEN structures
+                            // (id U32, x U16, y U16, width U16, height U16, flags U32)
+                            let number_of_screens = stream.read_u8().await?;
+                            let mut padding = [0; 3];
+                            stream.read_exact(&mut padding).await?;
+                            let mut layout = Vec::with_capacity(number_of_screens as usize);
+                            for _ in 0..number_of_screens {
+                                layout.push(ScreenLayout {
+                                    id: stream.read_u32().await?,
+                                    x: stream.read_u16().await?,
+                                    y: stream.read_u16().await?,
+                                    width: stream.read_u16().await?,
+                                    height: stream.read_u16().await?,
+                                    flags: stream.read_u32().await?,
+                                });
+                            }
+                            output_func(VncEvent::ExtendedDesktopSize {
+                                screen: (rect.rect.width, rect.rect.height).into(),
+                                reason: rect.rect.x as u8,
+                                status: rect.rect.y as u8,
+                                layout,
+                            })
                             .await?;
                         }
                         VncEncoding::LastRectPseudo => {

--- a/src/client/messages.rs
+++ b/src/client/messages.rs
@@ -1,4 +1,4 @@
-use crate::{PixelFormat, Rect, VncEncoding, VncError};
+use crate::{PixelFormat, Rect, ScreenLayout, VncEncoding, VncError};
 use tokio::io::{AsyncRead, AsyncReadExt, AsyncWrite, AsyncWriteExt};
 
 #[derive(Debug)]
@@ -9,6 +9,7 @@ pub(super) enum ClientMsg {
     KeyEvent(u32, bool),
     PointerEvent(u16, u16, u8),
     ClientCutText(String),
+    SetDesktopSize(u16, u16, Vec<ScreenLayout>),
 }
 
 impl ClientMsg {
@@ -98,6 +99,42 @@ impl ClientMsg {
                 let mut payload = vec![5, mask];
                 payload.write_u16(x).await?;
                 payload.write_u16(y).await?;
+                writer.write_all(&payload).await?;
+                Ok(())
+            }
+            ClientMsg::SetDesktopSize(width, height, screens) => {
+                // +--------------+--------------+-------------------+
+                // | No. of bytes | Type [Value] | Description       |
+                // +--------------+--------------+-------------------+
+                // | 1            | U8 [251]     | message-type      |
+                // | 1            |              | padding           |
+                // | 2            | U16          | width             |
+                // | 2            | U16          | height            |
+                // | 1            | U8           | number-of-screens |
+                // | 1            |              | padding           |
+                // +--------------+--------------+-------------------+
+                // Followed by number-of-screens SCREEN structures:
+                // +--------------+--------------+--------------+
+                // | 4            | U32          | id           |
+                // | 2            | U16          | x-position   |
+                // | 2            | U16          | y-position   |
+                // | 2            | U16          | width        |
+                // | 2            | U16          | height       |
+                // | 4            | U32          | flags        |
+                // +--------------+--------------+--------------+
+                let mut payload = vec![251_u8, 0];
+                payload.extend_from_slice(&width.to_be_bytes());
+                payload.extend_from_slice(&height.to_be_bytes());
+                payload.push(screens.len() as u8);
+                payload.push(0);
+                for s in screens {
+                    payload.extend_from_slice(&s.id.to_be_bytes());
+                    payload.extend_from_slice(&s.x.to_be_bytes());
+                    payload.extend_from_slice(&s.y.to_be_bytes());
+                    payload.extend_from_slice(&s.width.to_be_bytes());
+                    payload.extend_from_slice(&s.height.to_be_bytes());
+                    payload.extend_from_slice(&s.flags.to_be_bytes());
+                }
                 writer.write_all(&payload).await?;
                 Ok(())
             }
@@ -191,5 +228,57 @@ impl ServerMsg {
             }
             _ => Err(VncError::WrongServerMessage),
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ScreenLayout;
+
+    async fn serialize(msg: ClientMsg) -> Vec<u8> {
+        let mut buf = Vec::new();
+        msg.write(&mut buf).await.unwrap();
+        buf
+    }
+
+    #[tokio::test]
+    async fn set_desktop_size_wire_format() {
+        let screens = vec![ScreenLayout {
+            id: 0x11223344,
+            x: 0,
+            y: 0,
+            width: 1280,
+            height: 720,
+            flags: 0xAABBCCDD,
+        }];
+        let buf = serialize(ClientMsg::SetDesktopSize(1280, 720, screens)).await;
+
+        assert_eq!(buf.len(), 8 + 16, "header + one SCREEN struct");
+        assert_eq!(buf[0], 251, "message-type");
+        assert_eq!(buf[1], 0, "padding");
+        assert_eq!(u16::from_be_bytes([buf[2], buf[3]]), 1280);
+        assert_eq!(u16::from_be_bytes([buf[4], buf[5]]), 720);
+        assert_eq!(buf[6], 1, "number-of-screens");
+        assert_eq!(buf[7], 0, "padding");
+        assert_eq!(u32::from_be_bytes([buf[8], buf[9], buf[10], buf[11]]), 0x11223344);
+        assert_eq!(u16::from_be_bytes([buf[12], buf[13]]), 0, "x");
+        assert_eq!(u16::from_be_bytes([buf[14], buf[15]]), 0, "y");
+        assert_eq!(u16::from_be_bytes([buf[16], buf[17]]), 1280);
+        assert_eq!(u16::from_be_bytes([buf[18], buf[19]]), 720);
+        assert_eq!(
+            u32::from_be_bytes([buf[20], buf[21], buf[22], buf[23]]),
+            0xAABBCCDD
+        );
+    }
+
+    #[tokio::test]
+    async fn framebuffer_update_request_wire_format_unchanged() {
+        let rect = Rect { x: 0, y: 0, width: 1920, height: 1080 };
+        let buf = serialize(ClientMsg::FramebufferUpdateRequest(rect, 1)).await;
+        assert_eq!(buf[0], 3);
+        assert_eq!(buf[1], 1, "incremental");
+        assert_eq!(u16::from_be_bytes([buf[6], buf[7]]), 1920);
+        assert_eq!(u16::from_be_bytes([buf[8], buf[9]]), 1080);
     }
 }

--- a/src/config.rs
+++ b/src/config.rs
@@ -16,6 +16,7 @@ pub enum VncEncoding {
     CursorPseudo = -239,
     DesktopSizePseudo = -223,
     LastRectPseudo = -224,
+    ExtendedDesktopSizePseudo = -308,
 }
 
 impl From<u32> for VncEncoding {
@@ -32,6 +33,7 @@ impl From<u32> for VncEncoding {
             -239 => VncEncoding::CursorPseudo,
             -223 => VncEncoding::DesktopSizePseudo,
             -224 => VncEncoding::LastRectPseudo,
+            -308 => VncEncoding::ExtendedDesktopSizePseudo,
             _ => VncEncoding::Raw,
         }
     }

--- a/src/event.rs
+++ b/src/event.rs
@@ -27,6 +27,20 @@ impl From<(u16, u16)> for Screen {
     }
 }
 
+/// One screen in an ExtendedDesktopSize layout
+///
+/// According to the [ExtendedDesktopSize pseudo-encoding](https://github.com/rfbproto/rfbproto/blob/master/rfbproto.rst#extendeddesktopsize-pseudo-encoding)
+///
+#[derive(Debug, Clone, Copy)]
+pub struct ScreenLayout {
+    pub id: u32,
+    pub x: u16,
+    pub y: u16,
+    pub width: u16,
+    pub height: u16,
+    pub flags: u32,
+}
+
 type SrcRect = Rect;
 type DstRect = Rect;
 
@@ -48,6 +62,22 @@ pub enum VncEvent {
     /// If the [crate::VncEncoding::DesktopSizePseudo] is set
     ///
     SetResolution(Screen),
+    /// Will be generated if [crate::VncEncoding::ExtendedDesktopSizePseudo] is set
+    /// and the server supports it (servers announce support by sending one of
+    /// these immediately after SetEncodings, and use it INSTEAD of
+    /// [VncEvent::SetResolution] for all later size changes).
+    ///
+    /// `reason` 0 = server/administrative resize, 1 = this client's
+    /// SetDesktopSize request, 2 = another client's request.
+    /// `status` is only meaningful when `reason == 1`; non-zero means the
+    /// request failed and `screen`/`layout` must be ignored.
+    ///
+    ExtendedDesktopSize {
+        screen: Screen,
+        reason: u8,
+        status: u8,
+        layout: Vec<ScreenLayout>,
+    },
     /// If the connector doesn't call `set_pixel_format` method
     ///
     /// The engine will generate a [VncEvent::SetPixelFormat] to let the window know how to render image
@@ -138,6 +168,18 @@ pub enum X11Event {
     /// Forces the server to send the entire framebuffer, useful after
     /// CursorPseudo is negotiated to clear cursor ghosts from the framebuffer.
     FullRefresh,
+    /// Ask the server to change the desktop size (width, height).
+    ///
+    /// Requires [crate::VncEncoding::ExtendedDesktopSizePseudo] to be set AND
+    /// the server to have announced support (a
+    /// [VncEvent::ExtendedDesktopSize] was received) — sending it to a server
+    /// that doesn't support it is a protocol error and the server may close
+    /// the connection.
+    ///
+    /// The server answers with a [VncEvent::ExtendedDesktopSize] with
+    /// `reason == 1` carrying the result status.
+    ///
+    SetDesktopSize(u16, u16),
     /// Key down/up
     ///
     KeyEvent(ClientKeyEvent),


### PR DESCRIPTION
Adds support for the [ExtendedDesktopSize pseudo-encoding](https://github.com/rfbproto/rfbproto/blob/master/rfbproto.rst#extendeddesktopsize-pseudo-encoding) and the `SetDesktopSize` client message, so a client can both
learn the server's screen layout and request a desktop size.

Today a client can only observe resolution changes (`DesktopSizePseudo`), never
request one. Servers that support resizing (TigerVNC, x11vnc with RandR, GNOME
Remote Desktop) expose it through `SetDesktopSize`, which requires
ExtendedDesktopSize to have been negotiated first.

While implementing this I also hit a bug in the existing resize path, see the
second commit


## Changes

**`VncEncoding::ExtendedDesktopSizePseudo = -308`** (`config.rs`), including the
`From<u32>` mapping.

**`VncEvent::ExtendedDesktopSize { screen, reason, status, layout }`**
(`event.rs`) with a new public `ScreenLayout` struct. Per the spec, `x`/`y` of
the rect carry `reason`/`status` rather than coordinates, and the payload is a
screen count followed by that many `SCREEN` structures. `status` is only
meaningful when `reason == 1` (a response to this client's own request).

**`X11Event::SetDesktopSize(width, height)`** (`event.rs`) →
`ClientMsg::SetDesktopSize` (`messages.rs`), serialised per the spec. The
message echoes the server-announced layout with the primary screen resized;
multi-monitor layouts are collapsed to a single screen, since servers reject
layouts whose screens don't tile the requested size. Documented as requiring the
server to have announced support first, sending it unannounced is a protocol
error.

**Screen-size tracking** (`connection.rs`): `VncInner` now updates its cached
`screen` when it hands a `SetResolution`/`ExtendedDesktopSize` event to the
consumer, and remembers the last announced `ScreenLayout`.

This last part is a **bug fix independent of the new feature**. `VncInner.screen`
was only ever set in `new()`, but every `FramebufferUpdateRequest` is built from
it. After the desktop resized, the client kept requesting the *old* rectangle
forever, so when a desktop grew, the server never sent the region outside the
original bounds, and it stayed blank permanently. It reproduces on stock 0.5.3
with any server that resizes mid-session.

Two unit tests in `messages.rs` covering the `SetDesktopSize` wire format
byte-for-byte, and a guard that `FramebufferUpdateRequest`'s encoding is
unchanged. `cargo test` passes.

## Side effect ?

New variants aren't a breaking change. Servers ignore encodings they don't advertise support
for, so registering `ExtendedDesktopSizePseudo` is safe against older servers.

## Validation

Exercised against TigerVNC over the internet (a VPS): connected at 1920x1080, requested
1280x720 and 1024x768, verified the decoded framebuffer came back at exactly the
requested size each time and that the restored size took effect. The screen
tracking fix was validated by confirming that regions outside the original
bounds (a desktop panel and dock) render after a resize, where previously they
stayed blank.

I've left the version in `Cargo.toml` alone, happy to bump it to 0.5.4 or
whatever you prefer if you'd like that in the same PR.